### PR TITLE
Small bug fixes and rework of API.

### DIFF
--- a/examples/gadget-acm-ecm.c
+++ b/examples/gadget-acm-ecm.c
@@ -97,8 +97,8 @@ int main(void)
 		goto out2;
 	}
 
-	usbg_ret = usbg_create_config(g, "c.1", NULL /* use defaults */, &c_strs,
-			&c);
+	/* NULL can be passed to use kernel defaults */
+	usbg_ret = usbg_create_config(g, 1, "The only one", NULL, &c_strs, &c);
 	if (usbg_ret != USBG_SUCCESS) {
 		fprintf(stderr, "Error creating config\n");
 		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -70,11 +70,13 @@ void show_gadget(usbg_gadget *g)
 
 void show_function(usbg_function *f)
 {
-	char buf[USBG_MAX_STR_LENGTH];
+	char instance[USBG_MAX_STR_LENGTH];
+	usbg_function_type type;
 	int usbg_ret;
 	usbg_function_attrs f_attrs;
 
-	usbg_get_function_name(f, buf, USBG_MAX_STR_LENGTH);
+	usbg_get_function_instance(f, instance, USBG_MAX_STR_LENGTH);
+	type = usbg_get_function_type(f);
 	usbg_ret = usbg_get_function_attrs(f, &f_attrs);
 	if (usbg_ret != USBG_SUCCESS) {
 		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
@@ -82,8 +84,9 @@ void show_function(usbg_function *f)
 		return;
 	}
 
-	fprintf(stdout, "  Function '%s'\n", buf);
-	switch (usbg_get_function_type(f)) {
+	fprintf(stdout, "  Function, type: %s instance: %s\n",
+			usbg_get_function_type_str(type), instance);
+	switch (type) {
 	case F_SERIAL:
 	case F_ACM:
 	case F_OBEX:
@@ -114,7 +117,8 @@ void show_config(usbg_config *c)
 {
 	usbg_binding *b;
 	usbg_function *f;
-	char buf[USBG_MAX_STR_LENGTH], buf2[USBG_MAX_STR_LENGTH];
+	char buf[USBG_MAX_STR_LENGTH], instance[USBG_MAX_STR_LENGTH];
+	usbg_function_type type;
 	usbg_config_attrs c_attrs;
 	usbg_config_strs c_strs;
 	int usbg_ret;
@@ -144,8 +148,10 @@ void show_config(usbg_config *c)
 	usbg_for_each_binding(b, c) {
 		usbg_get_binding_name(b, buf, USBG_MAX_STR_LENGTH);
 		f = usbg_get_binding_target(b);
-		usbg_get_function_name(f, buf2, USBG_MAX_STR_LENGTH);
-		fprintf(stdout, "    %s -> %s\n", buf, buf2);
+		usbg_get_function_instance(f, instance, USBG_MAX_STR_LENGTH);
+		type = usbg_get_function_type(f);
+		fprintf(stdout, "    %s -> %s %s\n", buf,
+				usbg_get_function_type_str(type), instance);
 	}
 }
 

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -57,7 +57,7 @@ void show_gadget(usbg_gadget *g)
 	fprintf(stdout, "  idVendor\t\t0x%04x\n", g_attrs.idVendor);
 	fprintf(stdout, "  idProduct\t\t0x%04x\n", g_attrs.idProduct);
 
-	usbg_get_gadget_strs(g, LANG_US_ENG, &g_strs);
+	usbg_ret = usbg_get_gadget_strs(g, LANG_US_ENG, &g_strs);
 	if (usbg_ret != USBG_SUCCESS) {
 		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
 				usbg_strerror(usbg_ret));
@@ -121,10 +121,11 @@ void show_config(usbg_config *c)
 	usbg_function_type type;
 	usbg_config_attrs c_attrs;
 	usbg_config_strs c_strs;
-	int usbg_ret;
+	int usbg_ret, id;
 
-	usbg_get_config_name(c, buf, USBG_MAX_STR_LENGTH);
-	fprintf(stdout, "  Configuration '%s'\n", buf);
+	usbg_get_config_label(c, buf, USBG_MAX_STR_LENGTH);
+	id = usbg_get_config_id(c);
+	fprintf(stdout, "  Configuration: '%s' ID: %d\n", buf, id);
 
 	usbg_ret = usbg_get_config_attrs(c, &c_attrs);
 	if (usbg_ret != USBG_SUCCESS) {

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -37,6 +37,7 @@
 
 #define DEFAULT_UDC		NULL
 #define LANG_US_ENG		0x0409
+#define DEFAULT_CONFIG_LABEL "config"
 
 #define USBG_MAX_STR_LENGTH 256
 #define USBG_MAX_PATH_LENGTH PATH_MAX
@@ -266,10 +267,14 @@ extern usbg_function *usbg_get_function(usbg_gadget *g,
 /**
  * @brief Get a configuration by name
  * @param g Pointer to gadget
- * @param name Name of the configuration
+ * @param id Identify of configuration
+ * @param label Configuration label. If not NULL this function will return
+ * valid value only if configuration with given id exist and has this label.
+ * If NULL this function will return config with given id (if such exist)
+ * and ignore this param.
  * @return Pointer to config or NULL if a matching config isn't found
  */
-extern usbg_config *usbg_get_config(usbg_gadget *g, const char *name);
+extern usbg_config *usbg_get_config(usbg_gadget *g, int id, const char *label);
 
 /* USB gadget allocation and configuration */
 
@@ -491,31 +496,39 @@ extern const char *usbg_get_function_type_str(usbg_function_type type);
 /**
  * @brief Create a new USB gadget configuration
  * @param g Pointer to gadget
- * @param name Name of configuration
+ * @param id Identify of configuration
+ * @param label configuration label, if NULL, default is used
  * @param c_attrs Configuration attributes to be set
  * @param c_strs Configuration strings to be set
  * @param c Pointer to be filled with pointer to configuration
  * @note Given strings are assumed to be in US English
  * @return 0 on success usbg_error if error occurred
  */
-extern int usbg_create_config(usbg_gadget *g, char *name,
+extern int usbg_create_config(usbg_gadget *g, int id, const char *label,
 		usbg_config_attrs *c_attrs, usbg_config_strs *c_strs, usbg_config **c);
 
 /**
- * @brief Get config name length
- * @param c Config which name length should be returned
- * @return Length of name string or usbg_error if error occurred.
+ * @brief Get config label length
+ * @param c Config which label length should be returned
+ * @return Length of label or usbg_error if error occurred.
  */
-extern size_t usbg_get_config_name_len(usbg_config *c);
+extern size_t usbg_get_config_label_len(usbg_config *c);
 
 /**
- * @brieg Get config name
+ * @brieg Get config label
  * @param c Pointer to config
- * @param buf Buffer where name should be copied
+ * @param buf Buffer where label should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_config_name(usbg_config *c, char *buf, size_t len);
+extern int usbg_get_config_label(usbg_config *c, char *buf, size_t len);
+
+/**
+ * @brieg Get config id
+ * @param c Pointer to config
+ * @return Configuration id or usbg_error if error occurred.
+ */
+extern int usbg_get_config_id(usbg_config *c);
 
 /**
  * @brief Set the USB configuration attributes

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -256,10 +256,12 @@ extern usbg_gadget *usbg_get_gadget(usbg_state *s, const char *name);
 /**
  * @brief Get a function by name
  * @param g Pointer to gadget
- * @param name Name of the function
+ * @param type Function type
+ * @param instance Instance of function
  * @return Pointer to function or NULL if a matching function isn't found
  */
-extern usbg_function *usbg_get_function(usbg_gadget *g, const char *name);
+extern usbg_function *usbg_get_function(usbg_gadget *g,
+		usbg_function_type type, const char *instance);
 
 /**
  * @brief Get a configuration by name
@@ -462,20 +464,27 @@ extern int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 		char *instance, usbg_function_attrs *f_attrs, usbg_function **f);
 
 /**
- * @brief Get function name length
- * @param f Config which name length should be returned
+ * @brief Get function instance name length
+ * @param f function which name length should be returned
  * @return Length of name string or usbg_error if error occurred.
  */
-extern size_t usbg_get_function_name_len(usbg_function *f);
+extern size_t usbg_get_function_instance_len(usbg_function *f);
 
 /**
- * @brieg Get config name
+ * @brief Get function instance name
  * @param f Pointer to function
- * @param buf Buffer where name should be copied
+ * @param buf Buffer where instance name should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_function_name(usbg_function *f, char *buf, size_t len);
+extern int usbg_get_function_instance(usbg_function *f, char *buf, size_t len);
+
+/**
+ * @brief Get function type as a string
+ * @param type Function type
+ * @return String suitable for given function type
+ */
+extern const char *usbg_get_function_type_str(usbg_function_type type);
 
 /* USB configurations allocation and configuration */
 
@@ -651,8 +660,8 @@ extern int usbg_get_gadget_udc(usbg_gadget *g, char *buf, size_t len);
 /**
  * @brief Get type of given function
  * @param f Pointer to function
- * @return Type of function
- * @warning Pointer to function has to be valid.
+ * @return usbg_function_type (0 or above) or
+ *  usbg_error (below 0) if error occurred
  */
 extern usbg_function_type usbg_get_function_type(usbg_function *f);
 

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -844,6 +844,12 @@ static int usbg_parse_gadget_attrs(char *path, char *name,
 	else
 		goto out;
 
+	ret = usbg_read_hex(path, name, "bcdDevice", &buf);
+	if (ret == USBG_SUCCESS)
+		g_attrs->bcdDevice = (uint16_t) buf;
+	else
+		goto out;
+
 	ret = usbg_read_hex(path, name, "bDeviceClass", &buf);
 	if (ret == USBG_SUCCESS)
 		g_attrs->bDeviceClass = (uint8_t)buf;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -482,7 +482,7 @@ static usbg_gadget *usbg_allocate_gadget(char *path, char *name,
 {
 	usbg_gadget *g;
 
-	g = malloc(sizeof(usbg_gadget));
+	g = malloc(sizeof(*g));
 	if (g) {
 		TAILQ_INIT(&g->functions);
 		TAILQ_INIT(&g->configs);
@@ -506,7 +506,7 @@ static usbg_config *usbg_allocate_config(char *path, char *name,
 {
 	usbg_config *c;
 
-	c = malloc(sizeof(usbg_config));
+	c = malloc(sizeof(*c));
 	if (c) {
 		TAILQ_INIT(&c->bindings);
 		c->name = strdup(name);
@@ -529,7 +529,7 @@ static usbg_function *usbg_allocate_function(char *path, char *name,
 {
 	usbg_function *f;
 
-	f = malloc(sizeof(usbg_config));
+	f = malloc(sizeof(*f));
 	if (f) {
 		f->name = strdup(name);
 		f->path = strdup(path);
@@ -551,7 +551,7 @@ static usbg_binding *usbg_allocate_binding(char *path, char *name,
 {
 	usbg_binding *b;
 
-	b = malloc(sizeof(usbg_config));
+	b = malloc(sizeof(*b));
 	if (b) {
 		b->name = strdup(name);
 		b->path = strdup(path);

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -283,6 +283,13 @@ static int usbg_lookup_function_type(char *name)
 	return i;
 }
 
+static inline const char *usbg_get_function_type_name(
+		usbg_function_type type)
+{
+	return type > 0 && type < sizeof(function_names)/sizeof(char *) ?
+			function_names[type] : NULL;
+}
+
 static int bindings_select(const struct dirent *dent)
 {
 	if (dent->d_type == DT_LNK)
@@ -1473,6 +1480,7 @@ int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 {
 	char fpath[USBG_MAX_PATH_LENGTH];
 	char name[USBG_MAX_PATH_LENGTH];
+	const char *type_name;
 	usbg_function *func;
 	int ret = USBG_ERROR_INVALID_PARAM;
 	int n, free_space;
@@ -1480,11 +1488,11 @@ int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 	if (!g || !f)
 		return ret;
 
-	/**
-	 * @todo Check for legal function type
-	 */
-	n = snprintf(name, sizeof(name), "%s.%s",
-			function_names[type], instance);
+	type_name = usbg_get_function_type_name(type);
+	if (!type_name)
+		goto out;
+
+	n = snprintf(name, sizeof(name), "%s.%s", type_name, instance);
 	if (n >= sizeof(name)) {
 		ret = USBG_ERROR_PATH_TOO_LONG;
 		goto out;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <ctype.h>
 
 #define STRINGS_DIR "strings"
 #define CONFIGS_DIR "configs"
@@ -62,6 +63,8 @@ struct usbg_config
 
 	char *name;
 	char *path;
+	char *label;
+	int id;
 };
 
 struct usbg_function
@@ -324,6 +327,39 @@ out:
 	return ret;
 }
 
+static int usbg_split_config_label_id(const char *full_name,
+		char **label)
+{
+	int ret = USBG_ERROR_INVALID_PARAM;
+	char *dot, *endptr, *id_string;
+
+	dot = strrchr(full_name, '.');
+	id_string = dot + 1;
+	if (!dot || dot == full_name || *id_string == '\0'
+			|| isspace(*id_string))
+		goto out;
+
+	*label = strndup(full_name, dot - full_name);
+	if (!*label)
+		goto out;
+
+	errno = 0; /* clear errno */
+	ret = strtol(id_string, &endptr, 10);
+	if (errno) {
+		/* error occurred */
+		ret = usbg_translate_error(errno);
+		free(*label);
+		*label = NULL;
+		goto out;
+	}
+
+	if (*endptr != '\0' || ret < 0 || ret > 255)
+		ret = USBG_ERROR_INVALID_PARAM;
+
+out:
+	return ret;
+}
+
 static int bindings_select(const struct dirent *dent)
 {
 	if (dent->d_type == DT_LNK)
@@ -483,6 +519,7 @@ static void usbg_free_config(usbg_config *c)
 	}
 	free(c->path);
 	free(c->name);
+	free(c->label);
 	free(c);
 }
 
@@ -542,26 +579,39 @@ static usbg_gadget *usbg_allocate_gadget(char *path, char *name,
 	return g;
 }
 
-static usbg_config *usbg_allocate_config(char *path, char *name,
-		usbg_gadget *parent)
+static usbg_config *usbg_allocate_config(const char *path, const char *label,
+		int id, usbg_gadget *parent)
 {
 	usbg_config *c;
+	int ret;
 
 	c = malloc(sizeof(*c));
-	if (c) {
-		TAILQ_INIT(&c->bindings);
-		c->name = strdup(name);
-		c->path = strdup(path);
-		c->parent = parent;
+	if (!c)
+		goto out;
 
-		if (!(c->name) || !(c->path)) {
-			free(c->name);
-			free(c->path);
-			free(c);
-			c = NULL;
-		}
+	TAILQ_INIT(&c->bindings);
+
+	ret = asprintf(&(c->name), "%s.%d", label, id);
+	if (ret < 0) {
+		free(c);
+		c = NULL;
+		goto out;
 	}
 
+	c->path = strdup(path);
+	c->label = strdup(label);
+	c->parent = parent;
+	c->id = id;
+
+	if (!(c->path) || !(c->label)) {
+		free(c->name);
+		free(c->path);
+		free(c->label);
+		free(c);
+		c = NULL;
+	}
+
+out:
 	return c;
 }
 
@@ -875,9 +925,36 @@ out:
 	return ret;
 }
 
+static int usbg_parse_config(const char *path, const char *name,
+		usbg_gadget *g)
+{
+	int ret;
+	char *label = NULL;
+	usbg_config *c;
+
+	ret = usbg_split_config_label_id(name, &label);
+	if (ret <= 0)
+		goto out;
+
+	c = usbg_allocate_config(path, label, ret, g);
+	if (!c) {
+		ret = USBG_ERROR_NO_MEM;
+		goto out;
+	}
+
+	ret = usbg_parse_config_bindings(c);
+	if (ret == USBG_SUCCESS)
+		TAILQ_INSERT_TAIL(&g->configs, c, cnode);
+	else
+		usbg_free_config(c);
+
+out:
+	free(label);
+	return ret;
+}
+
 static int usbg_parse_configs(char *path, usbg_gadget *g)
 {
-	usbg_config *c;
 	int i, n;
 	int ret = USBG_SUCCESS;
 	struct dirent **dent;
@@ -891,26 +968,18 @@ static int usbg_parse_configs(char *path, usbg_gadget *g)
 	}
 
 	n = scandir(cpath, &dent, file_select, alphasort);
-	if (n >= 0) {
-		for (i = 0; i < n; i++) {
-			if (ret == USBG_SUCCESS) {
-				c = usbg_allocate_config(cpath, dent[i]->d_name, g);
-				if (c) {
-					ret = usbg_parse_config_bindings(c);
-					if (ret == USBG_SUCCESS)
-						TAILQ_INSERT_TAIL(&g->configs, c, cnode);
-					else
-						usbg_free_config(c);
-				} else {
-					ret = USBG_ERROR_NO_MEM;
-				}
-			}
-			free(dent[i]);
-		}
-		free(dent);
-	} else {
+	if (n < 0) {
 		ret = usbg_translate_error(errno);
+		goto out;
 	}
+
+	for (i = 0; i < n; i++) {
+		ret = ret == USBG_SUCCESS ?
+				usbg_parse_config(cpath, dent[i]->d_name, g)
+				: ret;
+		free(dent[i]);
+	}
+	free(dent);
 
 out:
 	return ret;
@@ -1161,15 +1230,15 @@ usbg_function *usbg_get_function(usbg_gadget *g,
 	return f;
 }
 
-usbg_config *usbg_get_config(usbg_gadget *g, const char *name)
+usbg_config *usbg_get_config(usbg_gadget *g, int id, const char *label)
 {
-	usbg_config *c;
+	usbg_config *c = NULL;
 
 	TAILQ_FOREACH(c, &g->configs, cnode)
-		if (!strcmp(c->name, name))
-			return c;
+		if (c->id == id && (!label || !strcmp(c->label, label)))
+			break;
 
-	return NULL;
+	return c;
 }
 
 usbg_binding *usbg_get_binding(usbg_config *c, const char *name)
@@ -1610,7 +1679,7 @@ out:
 	return ret;
 }
 
-int usbg_create_config(usbg_gadget *g, char *name,
+int usbg_create_config(usbg_gadget *g, int id, const char *label,
 		usbg_config_attrs *c_attrs, usbg_config_strs *c_strs, usbg_config **c)
 {
 	char cpath[USBG_MAX_PATH_LENGTH];
@@ -1618,15 +1687,15 @@ int usbg_create_config(usbg_gadget *g, char *name,
 	int ret = USBG_ERROR_INVALID_PARAM;
 	int n, free_space;
 
-	if (!g || !c)
+	if (!g || !c || id <= 0 || id > 255)
 		goto out;
 
-	/**
-	 * @todo Check for legal configuration name
-	 */
-	conf = usbg_get_config(g, name);
+	if (!label)
+		label = DEFAULT_CONFIG_LABEL;
+
+	conf = usbg_get_config(g, id, NULL);
 	if (conf) {
-		ERROR("duplicate configuration name\n");
+		ERROR("duplicate configuration id\n");
 		ret = USBG_ERROR_EXIST;
 		goto out;
 	}
@@ -1638,7 +1707,7 @@ int usbg_create_config(usbg_gadget *g, char *name,
 		goto out;
 	}
 
-	*c = usbg_allocate_config(cpath, name, g);
+	*c = usbg_allocate_config(cpath, label, id, g);
 	conf = *c;
 	if (!conf) {
 		ERRORNO("allocating configuration\n");
@@ -1648,22 +1717,22 @@ int usbg_create_config(usbg_gadget *g, char *name,
 
 	free_space = sizeof(cpath) - n;
 	/* Append string at the end of previous one */
-	n = snprintf(&(cpath[n]), free_space, "/%s", name);
+	n = snprintf(&(cpath[n]), free_space, "/%s", (*c)->name);
 	if (n < free_space) {
-		ret = mkdir(cpath, S_IRWXU | S_IRWXG | S_IRWXO);
-		if (!ret) {
-			ret = USBG_SUCCESS;
-			if (c_attrs)
-				ret = usbg_set_config_attrs(conf, c_attrs);
-
-			if (ret == USBG_SUCCESS && c_strs)
-				ret = usbg_set_config_string(conf, LANG_US_ENG,
-						c_strs->configuration);
-		} else {
-			ret = usbg_translate_error(errno);
-		}
-	} else {
 		ret = USBG_ERROR_PATH_TOO_LONG;
+	}
+
+	ret = mkdir(cpath, S_IRWXU | S_IRWXG | S_IRWXO);
+	if (!ret) {
+		ret = USBG_SUCCESS;
+		if (c_attrs)
+			ret = usbg_set_config_attrs(conf, c_attrs);
+
+		if (ret == USBG_SUCCESS && c_strs)
+			ret = usbg_set_config_string(conf, LANG_US_ENG,
+					c_strs->configuration);
+	} else {
+		ret = usbg_translate_error(errno);
 	}
 
 	if (ret == USBG_SUCCESS)
@@ -1676,20 +1745,25 @@ out:
 	return ret;
 }
 
-size_t usbg_get_config_name_len(usbg_config *c)
+size_t usbg_get_config_label_len(usbg_config *c)
 {
-	return c ? strlen(c->name) : USBG_ERROR_INVALID_PARAM;
+	return c ? strlen(c->label) : USBG_ERROR_INVALID_PARAM;
 }
 
-int usbg_get_config_name(usbg_config *c, char *buf, size_t len)
+int usbg_get_config_label(usbg_config *c, char *buf, size_t len)
 {
 	int ret = USBG_SUCCESS;
 	if (c && buf)
-		strncpy(buf, c->name, len);
+		strncpy(buf, c->label, len);
 	else
 		ret = USBG_ERROR_INVALID_PARAM;
 
 	return ret;
+}
+
+int usbg_get_config_id(usbg_config *c)
+{
+	return c ? c->id : USBG_ERROR_INVALID_PARAM;
 }
 
 size_t usbg_get_function_instance_len(usbg_function *f)


### PR DESCRIPTION
This is current series of patch from linux-usb mailing list. This series depends on all previous series so please merge them first and then this will be only 5 commits.

Description from linux-usb:
In this series of patch I have fixed some bugs introduced some time ago. First of it was a copy-pasta bug in functions which allocates memory and the second one was missing read of bcdDevice gadget attribute.

Second part of this series contains small rework of libusbg API.
In those patches I have change functions related to configuration and function.

Currently when user would like to get a function, he should pass the whole name as in ConfigFS, but user should not need to know what is the naming convention of this file system. After those patches user will specify function type and instance name instead of string with file name from ConfigFS.

Similar changes has been done in configuration related functions.
After my changes user will have to specify only the ID (number) for configuration. Label may be omitted and library will use some default name. ID of configuration is unique so it's enough to get configuration.

This series of patch depends on all my previous series. I have also updated github pull request.

Please review and merge.
