### PR TITLE
libusbg: Fix issues found with coverity

### DIFF
--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1787,7 +1787,7 @@ int usbg_set_config_attrs(usbg_config *c, usbg_config_attrs *c_attrs)
 {
 	int ret = USBG_ERROR_INVALID_PARAM;
 
-	if (c && !c_attrs) {
+	if (c && c_attrs) {
 		ret = usbg_write_dec(c->path, c->name, "MaxPower", c_attrs->bMaxPower);
 		if (ret == USBG_SUCCESS)
 			ret = usbg_write_hex8(c->path, c->name, "bmAttributes",

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -681,7 +681,7 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 		usbg_function_attrs *f_attrs)
 {
 	struct ether_addr *addr;
-	char str_addr[40];
+	char str_addr[USBG_MAX_STR_LENGTH];
 	int ret;
 
 	ret = usbg_read_string(f->path, f->name, "dev_addr", str_addr);

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1653,6 +1653,7 @@ int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 	if (!func) {
 		ERRORNO("allocating function\n");
 		ret = USBG_ERROR_NO_MEM;
+		goto out;
 	}
 
 	free_space = sizeof(fpath) - n;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -850,7 +850,7 @@ static int usbg_parse_config_binding(usbg_config *c, char *bpath,
 	usbg_function *f;
 	usbg_binding *b;
 
-	nmb = readlink(bpath, target, sizeof(target));
+	nmb = readlink(bpath, target, sizeof(target) - 1 );
 	if (nmb < 0) {
 		ret = usbg_translate_error(errno);
 		goto out;


### PR DESCRIPTION
When pushing the code through scan.coverity.com some issues with buffer underruns and dereferencing after NULL where found. This patch series fixes this.
