### PR TITLE
Small fixes and clean up

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,5 +1,6 @@
-bin_PROGRAMS = show-gadgets gadget-acm-ecm 
+bin_PROGRAMS = show-gadgets gadget-acm-ecm gadget-vid-pid-remove
 gadget_acm_ecm_SOURCES = gadget-acm-ecm.c
 show_gadgets_SOURCES = show-gadgets.c
+gadget_vid_pid_remove_SOURCES = gadget-vid-pid-remove.c
 AM_CPPFLAGS=-I../include/
 AM_LDFLAGS=-L../src/ -lusbg

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,7 @@
-bin_PROGRAMS = show-gadgets gadget-acm-ecm gadget-vid-pid-remove
+bin_PROGRAMS = show-gadgets gadget-acm-ecm gadget-vid-pid-remove gadget-ffs
 gadget_acm_ecm_SOURCES = gadget-acm-ecm.c
 show_gadgets_SOURCES = show-gadgets.c
 gadget_vid_pid_remove_SOURCES = gadget-vid-pid-remove.c
+gadget_ffs_SOURCES = gadget-ffs.c
 AM_CPPFLAGS=-I../include/
 AM_LDFLAGS=-L../src/ -lusbg

--- a/examples/gadget-ffs.c
+++ b/examples/gadget-ffs.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2014 Samsung Electronics
+ *
+ * Krzysztof Opasiak <k.opasiak@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file gadget-ffs.c
+ * @example gadget-ffs.c
+ * This is an example of how to create gadget with FunctionFS based functions
+ * in two ways. After executing this program gadget will not be enabled
+ * because ffs instances should be mounted and both descriptors and strings
+ * should be written to ep0.
+ * For more details about FunctionFS please refer to FunctionFS documentation
+ * in linux kernel repository.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <usbg/usbg.h>
+
+#define VENDOR          0x1d6b
+#define PRODUCT         0x0104
+
+int main(void)
+{
+	usbg_state *s;
+	usbg_gadget *g;
+	usbg_config *c;
+	usbg_function *f_ffs1, *f_ffs2;
+	int ret = -EINVAL;
+	int usbg_ret;
+	usbg_function_attrs f_attrs = {
+		.ffs = {
+			.dev_name = "my_awesome_dev_name",
+		},
+	};
+
+	usbg_gadget_attrs g_attrs = {
+			0x0200, /* bcdUSB */
+			0x00, /* Defined at interface level */
+			0x00, /* subclass */
+			0x00, /* device protocol */
+			0x0040, /* Max allowed packet size */
+			VENDOR,
+			PRODUCT,
+			0x0001, /* Verson of device */
+	};
+
+	usbg_gadget_strs g_strs = {
+			"0123456789", /* Serial number */
+			"Foo Inc.", /* Manufacturer */
+			"Bar Gadget" /* Product string */
+	};
+
+	usbg_config_strs c_strs = {
+			"2xFFS"
+	};
+
+	usbg_ret = usbg_init("/sys/kernel/config", &s);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on USB gadget init\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out1;
+	}
+
+	usbg_ret = usbg_create_gadget(s, "g1", &g_attrs, &g_strs, &g);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on create gadget\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	usbg_ret = usbg_create_function(g, F_FFS, "my_dev_name", NULL, &f_ffs1);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error creating ffs1 function\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	/* When NULL is passed as instance name, dev_name take from f_attrs
+	   is used as instance name for this function */
+	usbg_ret = usbg_create_function(g, F_FFS, NULL, &f_attrs, &f_ffs2);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error creating ffs2 function\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	/* NULL can be passed to use kernel defaults */
+	usbg_ret = usbg_create_config(g, 1, "The only one", NULL, &c_strs, &c);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error creating config\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	usbg_ret = usbg_add_config_function(c, "some_name_here", f_ffs1);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error adding ffs1\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	usbg_ret = usbg_add_config_function(c, "some_name_here_too", f_ffs2);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error adding ffs2\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	fprintf(stdout, "2xFFS gadget has been created.\n"
+		"Enable it after preparing your functions.\n");
+
+	/*
+	 * Here we end up with two created ffs instances but they are not
+	 * fully operational. Now we have to do step by step:
+	 * 1) Mount both instances:
+	 *    $ mount my_dev_name -t functionfs /path/to/mount/dir1
+	 *    $ mount my_awesome_dev_name -t functionfs /path/to/mount/dir2
+	 *
+	 * 2) Run ffs daemons for both instances:
+	 *    $ my-ffs-daemon /path/to/mount/dir1
+	 *    $ my-ffs-daemon /path/to/mount/dir2
+	 *
+	 * 3) Enable your gadget:
+	 *    $ echo "my_udc_name" > /sys/kernel/config/usb_gadget/g1/UDC
+	 */
+
+	ret = 0;
+
+out2:
+	usbg_cleanup(s);
+
+out1:
+	return ret;
+}

--- a/examples/gadget-vid-pid-remove.c
+++ b/examples/gadget-vid-pid-remove.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2014 Samsung Electronics
+ *
+ * Krzysztof Opasiak <k.opasiak@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file gadget-vid-pid-remove.c
+ * @example gadget-vid-pid-remove.c
+ * This is an example of how to find and remove an gadget device with given
+ * Vendor ID and product ID.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <usbg/usbg.h>
+
+#define VENDOR		0x1d6b
+#define PRODUCT		0x0104
+
+int remove_gadget(usbg_gadget *g)
+{
+	int usbg_ret;
+	char udc[USBG_MAX_STR_LENGTH];
+
+	/* Check if gadget is enabled */
+	usbg_ret = usbg_get_gadget_udc(g, udc, USBG_MAX_STR_LENGTH);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on USB get gadget udc\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out;
+	}
+
+	/* If gadget is enable we have to disable it first */
+	if (udc[0] != '\0') {
+		usbg_ret = usbg_disable_gadget(g);
+		if (usbg_ret != USBG_SUCCESS) {
+			fprintf(stderr, "Error on USB disable gadget udc\n");
+			fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+					usbg_strerror(usbg_ret));
+			goto out;
+		}
+	}
+
+	/* Remove gadget with USBG_RM_RECURSE flag to remove
+	 * also its configurations, functions and strings */
+	usbg_ret = usbg_rm_gadget(g, USBG_RM_RECURSE);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on USB gadget remove\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+	}
+
+out:
+	return usbg_ret;
+}
+
+int main(void)
+{
+	int usbg_ret;
+	int ret = -EINVAL;
+	usbg_state *s;
+	usbg_gadget *g;
+	usbg_gadget_attrs g_attrs;
+
+	usbg_ret = usbg_init("/sys/kernel/config", &s);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on USB state init\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out1;
+	}
+
+	g = usbg_get_first_gadget(s);
+	while (g != NULL) {
+		/* Get current gadget attrs to be compared */
+		usbg_ret = usbg_get_gadget_attrs(g, &g_attrs);
+		if (usbg_ret != USBG_SUCCESS) {
+			fprintf(stderr, "Error on USB get gadget attrs\n");
+			fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+					usbg_strerror(usbg_ret));
+			goto out2;
+		}
+
+		/* Compare attrs with given values and remove if suitable */
+		if (g_attrs.idVendor == VENDOR && g_attrs.idProduct == PRODUCT) {
+			usbg_gadget *g_next = usbg_get_next_gadget(g);
+
+			usbg_ret = remove_gadget(g);
+			if (usbg_ret != USBG_SUCCESS)
+				goto out2;
+
+			g = g_next;
+		} else {
+			g = usbg_get_next_gadget(g);
+		}
+	}
+
+out2:
+	usbg_cleanup(s);
+out1:
+	return ret;
+}

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -108,6 +108,9 @@ void show_function(usbg_function *f)
 	case F_PHONET:
 		fprintf(stdout, "    ifname\t\t%s\n", f_attrs.phonet.ifname);
 		break;
+	case F_FFS:
+		fprintf(stdout, "    dev_name\t\t%s\n", f_attrs.ffs.dev_name);
+		break;
 	default:
 		fprintf(stdout, "    UNKNOWN\n");
 	}

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -286,6 +286,22 @@ extern usbg_config *usbg_get_config(usbg_gadget *g, int id, const char *label);
  */
 extern int usbg_rm_binding(usbg_binding *b);
 
+/**
+ * @brief Remove configuration strings for given language
+ * @param c Pointer to configuration
+ * @param lang Language of strings which should be deleted
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_rm_config_strs(usbg_config *c, int lang);
+
+/**
+ * @brief Remove gadget strings for given language
+ * @param g Pointer to gadget
+ * @param lang Language of strings which should be deleted
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_rm_gadget_strs(usbg_gadget *g, int lang);
+
 /* USB gadget allocation and configuration */
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -312,6 +312,15 @@ extern int usbg_rm_config(usbg_config *c, int opts);
 extern int usbg_rm_function(usbg_function *f, int opts);
 
 /**
+ * @brief Remove existing USB gadget
+ * @details This function frees also the memory allocated for gadget
+ * @param g Gadget to be removed
+ * @param opts Additional options for configuration removal.
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_rm_gadget(usbg_gadget *g, int opts);
+
+/**
  * @brief Remove configuration strings for given language
  * @param c Pointer to configuration
  * @param lang Language of strings which should be deleted

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -41,6 +41,8 @@
 #define USBG_MAX_STR_LENGTH 256
 #define USBG_MAX_PATH_LENGTH PATH_MAX
 #define USBG_MAX_NAME_LENGTH 40
+/* Dev name for ffs is a part of function name, we subtracs 4 char for "ffs." */
+#define USBG_MAX_DEV_LENGTH (USBG_MAX_NAME_LENGTH - 4)
 
 /**
  * @brief Additional option for usbg_rm_* functions.
@@ -144,6 +146,7 @@ typedef enum
 	F_EEM,
 	F_RNDIS,
 	F_PHONET,
+	F_FFS
 } usbg_function_type;
 
 /**
@@ -174,6 +177,16 @@ typedef struct {
 } usbg_f_phonet_attrs;
 
 /**
+ * @typedef usbg_f_ffs_attrs
+ * @brief Attributes for function fs based functions
+ * @details This is read only and virtual attribute it is non present
+ * on config fs.
+ */
+typedef struct {
+	char dev_name[USBG_MAX_DEV_LENGTH];
+} usbg_f_ffs_attrs;
+
+/**
  * @typedef attrs
  * @brief Attributes for a given function type
  */
@@ -181,6 +194,7 @@ typedef union {
 	usbg_f_serial_attrs serial;
 	usbg_f_net_attrs net;
 	usbg_f_phonet_attrs phonet;
+	usbg_f_ffs_attrs ffs;
 } usbg_function_attrs;
 
 /* Error codes */

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -38,6 +38,7 @@
 #define LANG_US_ENG		0x0409
 #define DEFAULT_CONFIG_LABEL "config"
 
+/* This one has to be at least 18 bytes to hold network addres */
 #define USBG_MAX_STR_LENGTH 256
 #define USBG_MAX_PATH_LENGTH PATH_MAX
 #define USBG_MAX_NAME_LENGTH 40

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -25,7 +25,6 @@
 
 /**
  * @file include/usbg/usbg.h
- * @todo Add usbg_remove_[gadget|config|function|binding] APIs
  * @todo Clean up static buffers in structures
  */
 

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -276,6 +276,16 @@ extern usbg_function *usbg_get_function(usbg_gadget *g,
  */
 extern usbg_config *usbg_get_config(usbg_gadget *g, int id, const char *label);
 
+/* USB gadget/config/function/binding removal */
+
+/**
+ * @brief Remove binding between configuration and function
+ * @details This function frees also the memory allocated for binding
+ * @param b Binding to be removed
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_rm_binding(usbg_binding *b);
+
 /* USB gadget allocation and configuration */
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -43,6 +43,13 @@
 #define USBG_MAX_PATH_LENGTH PATH_MAX
 #define USBG_MAX_NAME_LENGTH 40
 
+/**
+ * @brief Additional option for usbg_rm_* functions.
+ * @details This option allows to remove all content
+ * of gadget/config/function recursive.
+ */
+#define USBG_RM_RECURSE 1
+
 /*
  * Internal structures
  */
@@ -285,6 +292,15 @@ extern usbg_config *usbg_get_config(usbg_gadget *g, int id, const char *label);
  * @return 0 on success, usbg_error if error occurred
  */
 extern int usbg_rm_binding(usbg_binding *b);
+
+/**
+ * @brief Remove configuration
+ * @details This function frees also the memory allocated for configuration
+ * @param c Configuration to be removed
+ * @param opts Additional options for configuration removal.
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_rm_config(usbg_config *c, int opts);
 
 /**
  * @brief Remove configuration strings for given language

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -303,6 +303,15 @@ extern int usbg_rm_binding(usbg_binding *b);
 extern int usbg_rm_config(usbg_config *c, int opts);
 
 /**
+ * @brief Remove existing USB function
+ * @details This function frees also the memory allocated for function
+ * @param f Function to be removed
+ * @param opts Additional options for configuration removal.
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_rm_function(usbg_function *f, int opts);
+
+/**
  * @brief Remove configuration strings for given language
  * @param c Pointer to configuration
  * @param lang Language of strings which should be deleted

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -240,7 +240,7 @@ extern const char *usbg_strerror(usbg_error e);
  * @param Pointer to be filled with pointer to usbg_state
  * @return 0 on success, usbg_error on error
  */
-extern int usbg_init(char *configfs_path, usbg_state **state);
+extern int usbg_init(const char *configfs_path, usbg_state **state);
 
 /**
  * @brief Clean up the libusbg library state
@@ -360,7 +360,7 @@ extern int usbg_rm_gadget_strs(usbg_gadget *g, int lang);
  * @param g Pointer to be filled with pointer to gadget
  * @return 0 on success usbg_error if error occurred
  */
-extern int usbg_create_gadget_vid_pid(usbg_state *s, char *name,
+extern int usbg_create_gadget_vid_pid(usbg_state *s, const char *name,
 		uint16_t idVendor, uint16_t idProduct, usbg_gadget **g);
 
 /**
@@ -374,8 +374,9 @@ extern int usbg_create_gadget_vid_pid(usbg_state *s, char *name,
  * @note Given strings are assumed to be in US English
  * @return 0 on success usbg_error if error occurred
  */
-extern int usbg_create_gadget(usbg_state *s, char *name,
-		usbg_gadget_attrs *g_attrs, usbg_gadget_strs *g_strs, usbg_gadget **g);
+extern int usbg_create_gadget(usbg_state *s, const char *name,
+		usbg_gadget_attrs *g_attrs, usbg_gadget_strs *g_strs,
+			      usbg_gadget **g);
 
 /**
  * @brief Set the USB gadget attributes
@@ -506,7 +507,8 @@ extern int usbg_set_gadget_strs(usbg_gadget *g, int lang,
  * @param ser Serial number
  * @return 0 on success usbg_error if error occurred
  */
-extern int usbg_set_gadget_serial_number(usbg_gadget *g, int lang, char *ser);
+extern int usbg_set_gadget_serial_number(usbg_gadget *g, int lang,
+					 const char *ser);
 
 /**
  * @brief Set the manufacturer name for a gadget
@@ -515,7 +517,8 @@ extern int usbg_set_gadget_serial_number(usbg_gadget *g, int lang, char *ser);
  * @param mnf Manufacturer
  * @return 0 on success usbg_error if error occurred
  */
-extern int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang, char *mnf);
+extern int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang,
+					const char *mnf);
 
 /**
  * @brief Set the product name for a gadget
@@ -524,7 +527,8 @@ extern int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang, char *mnf);
  * @param prd Product
  * @return 0 on success usbg_error if error occurred
  */
-extern int usbg_set_gadget_product(usbg_gadget *g, int lang, char *prd);
+extern int usbg_set_gadget_product(usbg_gadget *g, int lang,
+				   const char *prd);
 
 /* USB function allocation and configuration */
 
@@ -539,7 +543,8 @@ extern int usbg_set_gadget_product(usbg_gadget *g, int lang, char *prd);
  * @return 0 on success usbg_error if error occurred
  */
 extern int usbg_create_function(usbg_gadget *g, usbg_function_type type,
-		char *instance, usbg_function_attrs *f_attrs, usbg_function **f);
+		 const char *instance, usbg_function_attrs *f_attrs,
+				usbg_function **f);
 
 /**
  * @brief Get function instance name length
@@ -663,7 +668,7 @@ extern int usbg_set_config_strs(usbg_config *c, int lang,
  * @param string Configuration description
  * @return 0 on success, usbg_error on failure.
  */
-extern int usbg_set_config_string(usbg_config *c, int lang, char *string);
+extern int usbg_set_config_string(usbg_config *c, int lang, const char *string);
 
 /**
  * @brief Add a function to a configuration
@@ -672,7 +677,8 @@ extern int usbg_set_config_string(usbg_config *c, int lang, char *string);
  * @param f Pointer to function
  * @return 0 on success, usbg_error on failure.
  */
-extern int usbg_add_config_function(usbg_config *c, char *name, usbg_function *f);
+extern int usbg_add_config_function(usbg_config *c, const char *name,
+				    usbg_function *f);
 
 /**
  * @brief Get target function of given binding
@@ -712,7 +718,7 @@ extern int usbg_get_udcs(struct dirent ***udc_list);
  * @param udc Name of UDC to enable gadget
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_enable_gadget(usbg_gadget *g, char *udc);
+extern int usbg_enable_gadget(usbg_gadget *g, const char *udc);
 
 /**
  * @brief Disable a USB gadget device

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1787,7 +1787,7 @@ int usbg_set_config_attrs(usbg_config *c, usbg_config_attrs *c_attrs)
 {
 	int ret = USBG_ERROR_INVALID_PARAM;
 
-	if (c && !c_attrs) {
+	if (c && c_attrs) {
 		ret = usbg_write_dec(c->path, c->name, "MaxPower", c_attrs->bMaxPower);
 		if (ret == USBG_SUCCESS)
 			ret = usbg_write_hex8(c->path, c->name, "bmAttributes",

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -696,6 +696,23 @@ static int ubsg_rm_file(char *path, char *name)
 	return ret;
 }
 
+static int usbg_rm_dir(char *path, char *name)
+{
+	int ret = USBG_SUCCESS;
+	int nmb;
+	char buf[USBG_MAX_PATH_LENGTH];
+
+	nmb = snprintf(buf, sizeof(buf), "%s/%s", path, name);
+	if (nmb < sizeof(buf)) {
+		nmb = rmdir(buf);
+		if (nmb != 0)
+			ret = usbg_translate_error(errno);
+	} else {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+	}
+
+	return ret;
+}
 
 static int usbg_parse_function_net_attrs(usbg_function *f,
 		usbg_function_attrs *f_attrs)
@@ -1301,6 +1318,45 @@ int usbg_rm_binding(usbg_binding *b)
 
 	return ret;
 }
+
+int usbg_rm_config_strs(usbg_config *c, int lang)
+{
+	int ret = USBG_SUCCESS;
+	int nmb;
+	char path[USBG_MAX_PATH_LENGTH];
+
+	if (!c)
+		return USBG_ERROR_INVALID_PARAM;
+
+	nmb = snprintf(path, sizeof(path), "%s/%s/%s/0x%x", c->path, c->name,
+			STRINGS_DIR, lang);
+	if (nmb < sizeof(path))
+		ret = usbg_rm_dir(path, "");
+	else
+		ret = USBG_ERROR_PATH_TOO_LONG;
+
+	return ret;
+}
+
+int usbg_rm_gadget_strs(usbg_gadget *g, int lang)
+{
+	int ret = USBG_SUCCESS;
+	int nmb;
+	char path[USBG_MAX_PATH_LENGTH];
+
+	if (!g)
+		return USBG_ERROR_INVALID_PARAM;
+
+	nmb = snprintf(path, sizeof(path), "%s/%s/%s/0x%x", g->path, g->name,
+			STRINGS_DIR, lang);
+	if (nmb < sizeof(path))
+		ret = usbg_rm_dir(path, "");
+	else
+		ret = USBG_ERROR_PATH_TOO_LONG;
+
+	return ret;
+}
+
 
 static int usbg_create_empty_gadget(usbg_state *s, char *name, usbg_gadget **g)
 {

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -681,7 +681,7 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 		usbg_function_attrs *f_attrs)
 {
 	struct ether_addr *addr;
-	char str_addr[40];
+	char str_addr[USBG_MAX_STR_LENGTH];
 	int ret;
 
 	ret = usbg_read_string(f->path, f->name, "dev_addr", str_addr);

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1653,6 +1653,7 @@ int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 	if (!func) {
 		ERRORNO("allocating function\n");
 		ret = USBG_ERROR_NO_MEM;
+		goto out;
 	}
 
 	free_space = sizeof(fpath) - n;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -744,6 +744,7 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 		usbg_function_attrs *f_attrs)
 {
 	struct ether_addr *addr;
+	struct ether_addr addr_buf;
 	char str_addr[USBG_MAX_STR_LENGTH];
 	int ret;
 
@@ -751,7 +752,7 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 	if (ret != USBG_SUCCESS)
 		goto out;
 
-	addr = ether_aton(str_addr);
+	addr = ether_aton_r(str_addr, &addr_buf);
 	if (addr) {
 		f_attrs->net.dev_addr = *addr;
 	} else {
@@ -763,7 +764,7 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 	if (ret != USBG_SUCCESS)
 		goto out;
 
-	addr = ether_aton(str_addr);
+	addr = ether_aton_r(str_addr, &addr_buf);
 	if (addr) {
 		f_attrs->net.host_addr = *addr;
 	} else {
@@ -2314,6 +2315,7 @@ int usbg_get_function_attrs(usbg_function *f, usbg_function_attrs *f_attrs)
 int usbg_set_function_net_attrs(usbg_function *f, usbg_f_net_attrs *attrs)
 {
 	int ret = USBG_SUCCESS;
+	char addr_buf[USBG_MAX_STR_LENGTH];
 	char *addr;
 
 	/* ifname is read only so we accept only empty string for this param */
@@ -2322,12 +2324,12 @@ int usbg_set_function_net_attrs(usbg_function *f, usbg_f_net_attrs *attrs)
 		goto out;
 	}
 
-	addr = ether_ntoa(&attrs->dev_addr);
+	addr = ether_ntoa_r(&attrs->dev_addr, addr_buf);
 	ret = usbg_write_string(f->path, f->name, "dev_addr", addr);
 	if (ret != USBG_SUCCESS)
 		goto out;
 
-	addr = ether_ntoa(&attrs->host_addr);
+	addr = ether_ntoa_r(&attrs->host_addr, addr_buf);
 	ret = usbg_write_string(f->path, f->name, "host_addr", addr);
 	if (ret != USBG_SUCCESS)
 		goto out;
@@ -2386,7 +2388,8 @@ int usbg_set_net_dev_addr(usbg_function *f, struct ether_addr *dev_addr)
 	int ret = USBG_SUCCESS;
 
 	if (f && dev_addr) {
-		char *str_addr = ether_ntoa(dev_addr);
+		char str_buf[USBG_MAX_STR_LENGTH];
+		char *str_addr = ether_ntoa_r(dev_addr, str_buf);
 		ret = usbg_write_string(f->path, f->name, "dev_addr", str_addr);
 	} else {
 		ret = USBG_ERROR_INVALID_PARAM;
@@ -2400,7 +2403,8 @@ int usbg_set_net_host_addr(usbg_function *f, struct ether_addr *host_addr)
 	int ret = USBG_SUCCESS;
 
 	if (f && host_addr) {
-		char *str_addr = ether_ntoa(host_addr);
+		char str_buf[USBG_MAX_STR_LENGTH];
+		char *str_addr = ether_ntoa_r(host_addr, str_buf);
 		ret = usbg_write_string(f->path, f->name, "host_addr", str_addr);
 	} else {
 		ret = USBG_ERROR_INVALID_PARAM;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -269,7 +269,7 @@ const char *usbg_strerror(usbg_error e)
 	return ret;
 }
 
-static int usbg_lookup_function_type(char *name)
+static int usbg_lookup_function_type(const char *name)
 {
 	int i = 0;
 	int max = sizeof(function_names)/sizeof(char *);
@@ -378,7 +378,8 @@ static int file_select(const struct dirent *dent)
 		return 1;
 }
 
-static int usbg_read_buf(char *path, char *name, char *file, char *buf)
+static int usbg_read_buf(const char *path, const char *name, const char *file,
+			 char *buf)
 {
 	char p[USBG_MAX_PATH_LENGTH];
 	FILE *fp;
@@ -407,8 +408,8 @@ static int usbg_read_buf(char *path, char *name, char *file, char *buf)
 	return ret;
 }
 
-static int usbg_read_int(char *path, char *name, char *file, int base,
-		int *dest)
+static int usbg_read_int(const char *path, const char *name, const char *file,
+			 int base, int *dest)
 {
 	char buf[USBG_MAX_STR_LENGTH];
 	char *pos;
@@ -427,7 +428,8 @@ static int usbg_read_int(char *path, char *name, char *file, int base,
 #define usbg_read_dec(p, n, f, d)	usbg_read_int(p, n, f, 10, d)
 #define usbg_read_hex(p, n, f, d)	usbg_read_int(p, n, f, 16, d)
 
-static int usbg_read_string(char *path, char *name, char *file, char *buf)
+static int usbg_read_string(const char *path, const char *name,
+			    const char *file, char *buf)
 {
 	char *p = NULL;
 	int ret;
@@ -445,7 +447,8 @@ static int usbg_read_string(char *path, char *name, char *file, char *buf)
 	return ret;
 }
 
-static int usbg_write_buf(char *path, char *name, char *file, char *buf)
+static int usbg_write_buf(const char *path, const char *name, const char *file,
+			  const char *buf)
 {
 	char p[USBG_MAX_PATH_LENGTH];
 	FILE *fp;
@@ -475,8 +478,8 @@ static int usbg_write_buf(char *path, char *name, char *file, char *buf)
 	return ret;
 }
 
-static int usbg_write_int(char *path, char *name, char *file, int value,
-		char *str)
+static int usbg_write_int(const char *path, const char *name, const char *file,
+			  int value, const char *str)
 {
 	char buf[USBG_MAX_STR_LENGTH];
 	int nmb;
@@ -491,8 +494,8 @@ static int usbg_write_int(char *path, char *name, char *file, int value,
 #define usbg_write_hex16(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%04x\n")
 #define usbg_write_hex8(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%02x\n")
 
-static inline int usbg_write_string(char *path, char *name, char *file,
-		char *buf)
+static inline int usbg_write_string(const char *path, const char *name,
+				    const char *file, const char *buf)
 {
 	return usbg_write_buf(path, name, file, buf);
 }
@@ -557,7 +560,7 @@ static void usbg_free_state(usbg_state *s)
 	free(s);
 }
 
-static usbg_gadget *usbg_allocate_gadget(char *path, char *name,
+static usbg_gadget *usbg_allocate_gadget(const char *path, const char *name,
 		usbg_state *parent)
 {
 	usbg_gadget *g;
@@ -657,7 +660,7 @@ out:
 	return f;
 }
 
-static usbg_binding *usbg_allocate_binding(char *path, char *name,
+static usbg_binding *usbg_allocate_binding(const char *path, const char *name,
 		usbg_config *parent)
 {
 	usbg_binding *b;
@@ -679,7 +682,7 @@ static usbg_binding *usbg_allocate_binding(char *path, char *name,
 	return b;
 }
 
-static int ubsg_rm_file(char *path, char *name)
+static int ubsg_rm_file(const char *path, const char *name)
 {
 	int ret = USBG_SUCCESS;
 	int nmb;
@@ -697,7 +700,7 @@ static int ubsg_rm_file(char *path, char *name)
 	return ret;
 }
 
-static int usbg_rm_dir(char *path, char *name)
+static int usbg_rm_dir(const char *path, const char *name)
 {
 	int ret = USBG_SUCCESS;
 	int nmb;
@@ -715,7 +718,7 @@ static int usbg_rm_dir(char *path, char *name)
 	return ret;
 }
 
-static int usbg_rm_all_dirs(char *path)
+static int usbg_rm_all_dirs(const char *path)
 {
 	int ret = USBG_SUCCESS;
 	int n, i;
@@ -815,7 +818,7 @@ static int usbg_parse_function_attrs(usbg_function *f,
 	return ret;
 }
 
-static int usbg_parse_functions(char *path, usbg_gadget *g)
+static int usbg_parse_functions(const char *path, usbg_gadget *g)
 {
 	usbg_function *f;
 	int i, n;
@@ -860,7 +863,7 @@ out:
 	return ret;
 }
 
-static int usbg_parse_config_attrs(char *path, char *name,
+static int usbg_parse_config_attrs(const char *path, const char *name,
 		usbg_config_attrs *c_attrs)
 {
 	int buf, ret;
@@ -877,7 +880,7 @@ static int usbg_parse_config_attrs(char *path, char *name,
 	return ret;
 }
 
-static int usbg_parse_config_strs(char *path, char *name,
+static int usbg_parse_config_strs(const char *path, const char *name,
 		int lang, usbg_config_strs *c_strs)
 {
 	DIR *dir;
@@ -904,8 +907,7 @@ static int usbg_parse_config_strs(char *path, char *name,
 	return ret;
 }
 
-static int usbg_parse_config_binding(usbg_config *c, char *bpath,
-		int path_size)
+static int usbg_parse_config_binding(usbg_config *c, char *bpath, int path_size)
 {
 	int nmb;
 	int ret;
@@ -1019,7 +1021,7 @@ out:
 	return ret;
 }
 
-static int usbg_parse_configs(char *path, usbg_gadget *g)
+static int usbg_parse_configs(const char *path, usbg_gadget *g)
 {
 	int i, n;
 	int ret = USBG_SUCCESS;
@@ -1051,7 +1053,7 @@ out:
 	return ret;
 }
 
-static int usbg_parse_gadget_attrs(char *path, char *name,
+static int usbg_parse_gadget_attrs(const char *path, const char *name,
 		usbg_gadget_attrs *g_attrs)
 {
 	int buf, ret;
@@ -1110,7 +1112,7 @@ out:
 	return ret;
 }
 
-static int usbg_parse_gadget_strs(char *path, char *name, int lang,
+static int usbg_parse_gadget_strs(const char *path, const char *name, int lang,
 		usbg_gadget_strs *g_strs)
 {
 	int ret;
@@ -1166,7 +1168,7 @@ out:
 	return ret;
 }
 
-static int usbg_parse_gadgets(char *path, usbg_state *s)
+static int usbg_parse_gadgets(const char *path, usbg_state *s)
 {
 	usbg_gadget *g;
 	int i, n;
@@ -1220,7 +1222,7 @@ static int usbg_init_state(char *path, usbg_state *s)
  * User API
  */
 
-int usbg_init(char *configfs_path, usbg_state **state)
+int usbg_init(const char *configfs_path, usbg_state **state)
 {
 	int ret = USBG_SUCCESS;
 	DIR *dir;
@@ -1542,7 +1544,8 @@ int usbg_rm_gadget_strs(usbg_gadget *g, int lang)
 }
 
 
-static int usbg_create_empty_gadget(usbg_state *s, char *name, usbg_gadget **g)
+static int usbg_create_empty_gadget(usbg_state *s, const char *name,
+				    usbg_gadget **g)
 {
 	char gpath[USBG_MAX_PATH_LENGTH];
 	int nmb;
@@ -1581,7 +1584,7 @@ out:
 	return ret;
 }
 
-int usbg_create_gadget_vid_pid(usbg_state *s, char *name,
+int usbg_create_gadget_vid_pid(usbg_state *s, const char *name,
 		uint16_t idVendor, uint16_t idProduct, usbg_gadget **g)
 {
 	int ret;
@@ -1615,8 +1618,9 @@ int usbg_create_gadget_vid_pid(usbg_state *s, char *name,
 	return ret;
 }
 
-int usbg_create_gadget(usbg_state *s, char *name,
-		usbg_gadget_attrs *g_attrs, usbg_gadget_strs *g_strs, usbg_gadget **g)
+int usbg_create_gadget(usbg_state *s, const char *name,
+		       usbg_gadget_attrs *g_attrs, usbg_gadget_strs *g_strs,
+		       usbg_gadget **g)
 {
 	usbg_gadget *gad;
 	int ret;
@@ -1790,7 +1794,7 @@ int usbg_get_gadget_strs(usbg_gadget *g, int lang,
 			g_strs)	: USBG_ERROR_INVALID_PARAM;
 }
 
-static int usbg_check_dir(char *path)
+static int usbg_check_dir(const char *path)
 {
 	int ret = USBG_SUCCESS;
 	DIR *dir;
@@ -1839,7 +1843,7 @@ out:
 	return ret;
 }
 
-int usbg_set_gadget_serial_number(usbg_gadget *g, int lang, char *serno)
+int usbg_set_gadget_serial_number(usbg_gadget *g, int lang, const char *serno)
 {
 	int ret = USBG_ERROR_INVALID_PARAM;
 
@@ -1860,7 +1864,7 @@ int usbg_set_gadget_serial_number(usbg_gadget *g, int lang, char *serno)
 	return ret;
 }
 
-int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang, char *mnf)
+int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang, const char *mnf)
 {
 	int ret = USBG_ERROR_INVALID_PARAM;
 
@@ -1881,7 +1885,7 @@ int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang, char *mnf)
 	return ret;
 }
 
-int usbg_set_gadget_product(usbg_gadget *g, int lang, char *prd)
+int usbg_set_gadget_product(usbg_gadget *g, int lang, const char *prd)
 {
 	int ret = USBG_ERROR_INVALID_PARAM;
 
@@ -1903,7 +1907,8 @@ int usbg_set_gadget_product(usbg_gadget *g, int lang, char *prd)
 }
 
 int usbg_create_function(usbg_gadget *g, usbg_function_type type,
-		char *instance, usbg_function_attrs *f_attrs, usbg_function **f)
+			 const char *instance, usbg_function_attrs *f_attrs,
+			 usbg_function **f)
 {
 	char fpath[USBG_MAX_PATH_LENGTH];
 	usbg_function *func;
@@ -2118,7 +2123,7 @@ int usbg_set_config_strs(usbg_config *c, int lang,
 	return usbg_set_config_string(c, lang, c_strs->configuration);
 }
 
-int usbg_set_config_string(usbg_config *c, int lang, char *str)
+int usbg_set_config_string(usbg_config *c, int lang, const char *str)
 {
 	int ret = USBG_ERROR_INVALID_PARAM;
 
@@ -2139,7 +2144,7 @@ int usbg_set_config_string(usbg_config *c, int lang, char *str)
 	return ret;
 }
 
-int usbg_add_config_function(usbg_config *c, char *name, usbg_function *f)
+int usbg_add_config_function(usbg_config *c, const char *name, usbg_function *f)
 {
 	char bpath[USBG_MAX_PATH_LENGTH];
 	char fpath[USBG_MAX_PATH_LENGTH];
@@ -2245,7 +2250,7 @@ int usbg_get_udcs(struct dirent ***udc_list)
 	return ret;
 }
 
-int usbg_enable_gadget(usbg_gadget *g, char *udc)
+int usbg_enable_gadget(usbg_gadget *g, const char *udc)
 {
 	char gudc[USBG_MAX_STR_LENGTH];
 	struct dirent **udc_list;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -850,7 +850,7 @@ static int usbg_parse_config_binding(usbg_config *c, char *bpath,
 	usbg_function *f;
 	usbg_binding *b;
 
-	nmb = readlink(bpath, target, sizeof(target));
+	nmb = readlink(bpath, target, sizeof(target) - 1 );
 	if (nmb < 0) {
 		ret = usbg_translate_error(errno);
 		goto out;


### PR DESCRIPTION
This is a small series which fix usbg_set_function_attrs()
which previously tried to set attributes which are read only
on configfs.

I have also went through code and marked attributes which should not
change during function calls with const qualifiers.

Third patch is a small enhancement which replace ether_aton() and
ether_ntoa() calls with their reentrant versions ether_aton_r() and
ether_ntoa().
