### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = show-gadgets gadget-acm-ecm 
 gadget_acm_ecm_SOURCES = gadget-acm-ecm.c
 show_gadgets_SOURCES = show-gadgets.c
-AM_CPPFLAGS=-I../include/
+AM_CPPFLAGS=-I$(top_srcdir)/include/
 AM_LDFLAGS=-L../src/ -lusbg

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
 lib_LTLIBRARIES = libusbg.la
 libusbg_la_SOURCES = usbg.c
 libusbg_la_LDFLAGS = -version-info 0:1:0
-AM_CPPFLAGS=-I../include/
+AM_CPPFLAGS=-I$(top_srcdir)/include/


### PR DESCRIPTION
The include flag should point to the source directory, not the build
directory.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
