### PR TITLE
libusbg: Fixes and small API improvements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,3 @@
 Matt Porter <mporter@linaro.org>
+Krzysztof Opasiak <k.opasiak@samsung.com>
+

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -30,20 +30,26 @@
 void show_gadget(usbg_gadget *g)
 {
 	char buf[USBG_MAX_STR_LENGTH];
+	const char *name;
 	int usbg_ret;
 	usbg_gadget_attrs g_attrs;
 	usbg_gadget_strs g_strs;
 
-	usbg_get_gadget_name(g, buf, USBG_MAX_STR_LENGTH);
+	name = usbg_get_gadget_name(g);
+	if (!name) {
+		fprintf(stderr, "Unable to get gadget name\n");
+		return;
+	}
+
 	usbg_ret = usbg_get_gadget_attrs(g, &g_attrs);
 	if (usbg_ret != USBG_SUCCESS) {
 		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-				usbg_strerror(usbg_ret));
+			usbg_strerror(usbg_ret));
 		return;
 	}
 
 	fprintf(stdout, "ID %04x:%04x '%s'\n",
-			g_attrs.idVendor, g_attrs.idProduct, buf);
+			g_attrs.idVendor, g_attrs.idProduct, name);
 
 	usbg_get_gadget_udc(g, buf, USBG_MAX_STR_LENGTH);
 	fprintf(stdout, "  UDC\t\t\t%s\n", buf);
@@ -70,12 +76,17 @@ void show_gadget(usbg_gadget *g)
 
 void show_function(usbg_function *f)
 {
-	char instance[USBG_MAX_STR_LENGTH];
+	const char *instance;
 	usbg_function_type type;
 	int usbg_ret;
 	usbg_function_attrs f_attrs;
 
-	usbg_get_function_instance(f, instance, USBG_MAX_STR_LENGTH);
+	instance = usbg_get_function_instance(f);
+	if (!instance) {
+		fprintf(stderr, "Unable to get function instance name\n");
+		return;
+	}
+
 	type = usbg_get_function_type(f);
 	usbg_ret = usbg_get_function_attrs(f, &f_attrs);
 	if (usbg_ret != USBG_SUCCESS) {
@@ -120,15 +131,20 @@ void show_config(usbg_config *c)
 {
 	usbg_binding *b;
 	usbg_function *f;
-	char buf[USBG_MAX_STR_LENGTH], instance[USBG_MAX_STR_LENGTH];
+	const char *label, *instance, *bname;
 	usbg_function_type type;
 	usbg_config_attrs c_attrs;
 	usbg_config_strs c_strs;
 	int usbg_ret, id;
 
-	usbg_get_config_label(c, buf, USBG_MAX_STR_LENGTH);
+	label = usbg_get_config_label(c);
+	if (!label) {
+		fprintf(stderr, "Unable to get config label\n");
+		return;
+	}
+
 	id = usbg_get_config_id(c);
-	fprintf(stdout, "  Configuration: '%s' ID: %d\n", buf, id);
+	fprintf(stdout, "  Configuration: '%s' ID: %d\n", label, id);
 
 	usbg_ret = usbg_get_config_attrs(c, &c_attrs);
 	if (usbg_ret != USBG_SUCCESS) {
@@ -150,11 +166,15 @@ void show_config(usbg_config *c)
 	fprintf(stdout, "    configuration\t%s\n", c_strs.configuration);
 
 	usbg_for_each_binding(b, c) {
-		usbg_get_binding_name(b, buf, USBG_MAX_STR_LENGTH);
+		bname = usbg_get_binding_name(b);
 		f = usbg_get_binding_target(b);
-		usbg_get_function_instance(f, instance, USBG_MAX_STR_LENGTH);
+		instance = usbg_get_function_instance(f);
 		type = usbg_get_function_type(f);
-		fprintf(stdout, "    %s -> %s %s\n", buf,
+		if (!bname || !instance) {
+			fprintf(stderr, "Unable to get binding details\n");
+			return;
+		}
+		fprintf(stdout, "    %s -> %s %s\n", bname,
 				usbg_get_function_type_str(type), instance);
 	}
 }

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -255,6 +255,16 @@ extern int usbg_init(const char *configfs_path, usbg_state **state);
 extern void usbg_cleanup(usbg_state *s);
 
 /**
+ * @brief Get ConfigFS path
+ * @param s Pointer to state
+ * @return Path to configfs or NULL if error occurred
+ * @warning Returned buffer should not be edited!
+ * Returned string is valid as long as passed usbg_state is valid.
+ * For example path is valid unitill usbg_cleanup() call.
+ */
+extern const char *usbg_get_configfs_path(usbg_state *s);
+
+/**
  * @brief Get ConfigFS path length
  * @param s Pointer to state
  * @return Length of path or usbg_error if error occurred.
@@ -262,13 +272,13 @@ extern void usbg_cleanup(usbg_state *s);
 extern size_t usbg_get_configfs_path_len(usbg_state *s);
 
 /**
- * @brief Get ConfigFS path
+ * @brief Copy ConfigFS path to buffer
  * @param s Pointer to state
  * @param buf Buffer where path should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_configfs_path(usbg_state *s, char *buf, size_t len);
+extern int usbg_cpy_configfs_path(usbg_state *s, char *buf, size_t len);
 
 /* USB gadget queries */
 
@@ -402,6 +412,16 @@ extern int usbg_set_gadget_attrs(usbg_gadget *g,
 extern int usbg_get_gadget_attrs(usbg_gadget *g, usbg_gadget_attrs *g_attrs);
 
 /**
+ * @brief Get gadget name
+ * @param g Pointer to gadget
+ * @return Gadget name or NULL if error occurred.
+ * @warning Returned buffer should not be edited!
+ * Returned string is valid as long as passed usbg_gadget is valid.
+ * For example gadget name is valid until someone remove gadget.
+ */
+extern const char *usbg_get_gadget_name(usbg_gadget *g);
+
+/**
  * @brief Get gadget name length
  * @param g Gadget which name length should be returned
  * @return Length of name string or usbg_error if error occurred.
@@ -409,13 +429,13 @@ extern int usbg_get_gadget_attrs(usbg_gadget *g, usbg_gadget_attrs *g_attrs);
 extern size_t usbg_get_gadget_name_len(usbg_gadget *g);
 
 /**
- * @brief Get gadget name
+ * @brief Copy gadget name
  * @param g Pointer to gadget
  * @param buf Buffer where name should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_gadget_name(usbg_gadget *g, char *buf, size_t len);
+extern int usbg_cpy_gadget_name(usbg_gadget *g, char *buf, size_t len);
 
 /**
  * @brief Set the USB gadget vendor id
@@ -553,6 +573,16 @@ extern int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 				usbg_function **f);
 
 /**
+ * @brief Get function instance name
+ * @param f Pointer to function
+ * @return instance name or NULL if error occurred.
+ * @warning Returned buffer should not be edited!
+ * Returned string is valid as long as passed usbg_function is valid.
+ * For example instance name is valid until someone remove this function.
+ */
+extern const char *usbg_get_function_instance(usbg_function *f);
+
+/**
  * @brief Get function instance name length
  * @param f function which name length should be returned
  * @return Length of name string or usbg_error if error occurred.
@@ -560,13 +590,13 @@ extern int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 extern size_t usbg_get_function_instance_len(usbg_function *f);
 
 /**
- * @brief Get function instance name
+ * @brief Copy function instance name
  * @param f Pointer to function
  * @param buf Buffer where instance name should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_function_instance(usbg_function *f, char *buf, size_t len);
+extern int usbg_cpy_function_instance(usbg_function *f, char *buf, size_t len);
 
 /**
  * @brief Get function type as a string
@@ -592,6 +622,16 @@ extern int usbg_create_config(usbg_gadget *g, int id, const char *label,
 		usbg_config_attrs *c_attrs, usbg_config_strs *c_strs, usbg_config **c);
 
 /**
+ * @brief Get config label
+ * @param c Pointer to config
+ * @return config label or NULL if error occurred.
+ * @warning Returned buffer should not be edited!
+ * Returned string is valid as long as passed usbg_config is valid.
+ * For example config label is valid until someone remove this function.
+ */
+extern const char *usbg_get_config_label(usbg_config *c);
+
+/**
  * @brief Get config label length
  * @param c Config which label length should be returned
  * @return Length of label or usbg_error if error occurred.
@@ -599,13 +639,13 @@ extern int usbg_create_config(usbg_gadget *g, int id, const char *label,
 extern size_t usbg_get_config_label_len(usbg_config *c);
 
 /**
- * @brief Get config label
+ * @brief Copy config label
  * @param c Pointer to config
  * @param buf Buffer where label should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_config_label(usbg_config *c, char *buf, size_t len);
+extern int usbg_cpy_config_label(usbg_config *c, char *buf, size_t len);
 
 /**
  * @brief Get config id
@@ -694,6 +734,16 @@ extern int usbg_add_config_function(usbg_config *c, const char *name,
 extern usbg_function *usbg_get_binding_target(usbg_binding *b);
 
 /**
+ * @brief Get binding name
+ * @param b Pointer to binding
+ * @return Binding name or NULL if error occurred.
+ * @warning Returned buffer should not be edited!
+ * Returned string is valid as long as passed usbg_binding is valid.
+ * For example binding name is valid until someone remove this binding.
+ */
+extern const char *usbg_get_binding_name(usbg_binding *b);
+
+/**
  * @brief Get binding name length
  * @param b Binding which name length should be returned
  * @return Length of name string or usbg_error if error occurred.
@@ -701,13 +751,13 @@ extern usbg_function *usbg_get_binding_target(usbg_binding *b);
 extern size_t usbg_get_binding_name_len(usbg_binding *b);
 
 /**
- * @brief Get binding name
+ * @brief Copy binding name
  * @param b Pointer to binding
  * @param buf Buffer where name should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
  */
-extern int usbg_get_binding_name(usbg_binding *b, char *buf, size_t len);
+extern int usbg_cpy_binding_name(usbg_binding *b, char *buf, size_t len);
 
 /* USB gadget setup and teardown */
 

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -658,6 +658,13 @@ extern int usbg_cpy_function_instance(usbg_function *f, char *buf, size_t len);
  */
 extern const char *usbg_get_function_type_str(usbg_function_type type);
 
+/**
+ * @brief Lookup function type sutable for given name
+ * @param name Name of function
+ * @return Function type enum or negative error code
+ */
+extern int usbg_lookup_function_type(const char *name);
+
 /* USB configurations allocation and configuration */
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -88,6 +88,22 @@ typedef struct usbg_function usbg_function;
 typedef struct usbg_binding usbg_binding;
 
 /**
+ * @typedef usbg_gadget_attr
+ * @brief Gadget attributes which can be set using
+ * usbg_set_gadget_attr() function.
+ */
+typedef enum {
+	BCD_USB = 0,
+	B_DEVICE_CLASS,
+	B_DEVICE_SUB_CLASS,
+	B_DEVICE_PROTOCOL,
+	B_MAX_PACKET_SIZE_0,
+	ID_VENDOR,
+	ID_PRODUCT,
+	BCD_DEVICE,
+} usbg_gadget_attr;
+
+/**
  * @typedef usbg_gadget_attrs
  * @brief USB gadget device attributes
  */
@@ -393,6 +409,43 @@ extern int usbg_create_gadget_vid_pid(usbg_state *s, const char *name,
 extern int usbg_create_gadget(usbg_state *s, const char *name,
 		usbg_gadget_attrs *g_attrs, usbg_gadget_strs *g_strs,
 			      usbg_gadget **g);
+
+/**
+ * @brief Get string representing selected gadget attribute
+ * @param attr code of selected attrobute
+ * @return String suitable for given attribute or NULL if such
+ * string has not been found
+ */
+extern const char *usbg_get_gadget_attr_str(usbg_gadget_attr attr);
+
+/**
+ * @brief Lookup attr code based on its name
+ * @param name of attribute
+ * @return code of suitable attribute or usbg_error
+ */
+extern int usbg_lookup_gadget_attr(const char *name);
+
+/**
+ * @brief Set selected attribute to value
+ * @param g Pointer to gadget
+ * @param attr Code of selected attribute
+ * @param val value to be set
+ * @return 0 on success, usbg_error otherwise
+ * @note val is of type int but value provided to this function should
+ * be suitable to place it in type dedicated for selected attr (uint16 or uint8)
+ */
+extern int usbg_set_gadget_attr(usbg_gadget *g, usbg_gadget_attr attr, int val);
+
+/**
+ * @brief Get value of selected attribute
+ * @param g Pointer to gadget
+ * @param attr Code of selected attribute
+ * @return Value of selected attribute (always above zero) or
+ * usbg_error if error occurred.
+ * @note User should use only lowest one or two bytes as attribute value
+ * depending on attribute size (see usbg_gadget_attrs for details).
+ */
+extern int usbg_get_gadget_attr(usbg_gadget *g, usbg_gadget_attr attr);
 
 /**
  * @brief Set the USB gadget attributes

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -224,14 +224,14 @@ typedef enum  {
 	USBG_ERROR_OTHER_ERROR = -99
 } usbg_error;
 
-/*
+/**
  * @brief Get the error name as a constant string
  * @param e error code
  * @return Constant string with error name
  */
 extern const char *usbg_error_name(usbg_error e);
 
-/*
+/**
  * @brief Get the short description of error
  * @param e error code
  * @return Constant string with error description
@@ -243,7 +243,7 @@ extern const char *usbg_strerror(usbg_error e);
 /**
  * @brief Initialize the libusbg library state
  * @param configfs_path Path to the mounted configfs filesystem
- * @param Pointer to be filled with pointer to usbg_state
+ * @param state Pointer to be filled with pointer to usbg_state
  * @return 0 on success, usbg_error on error
  */
 extern int usbg_init(const char *configfs_path, usbg_state **state);
@@ -262,7 +262,7 @@ extern void usbg_cleanup(usbg_state *s);
 extern size_t usbg_get_configfs_path_len(usbg_state *s);
 
 /**
- * @brieg Get ConfigFS path
+ * @brief Get ConfigFS path
  * @param s Pointer to state
  * @param buf Buffer where path should be copied
  * @param len Length of given buffer
@@ -409,8 +409,8 @@ extern int usbg_get_gadget_attrs(usbg_gadget *g, usbg_gadget_attrs *g_attrs);
 extern size_t usbg_get_gadget_name_len(usbg_gadget *g);
 
 /**
- * @brieg Get gadget name
- * @param b Pointer to gadget
+ * @brief Get gadget name
+ * @param g Pointer to gadget
  * @param buf Buffer where name should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
@@ -490,7 +490,7 @@ extern int usbg_set_gadget_device_bcd_usb(usbg_gadget *g, uint16_t bcdUSB);
  * @brief Get the USB gadget strings
  * @param g Pointer to gadget
  * @param lang Language of strings
- * @param g_sttrs Structure to be filled
+ * @param g_strs Structure to be filled
  * @return 0 on success usbg_error if error occurred
  */
 extern int usbg_get_gadget_strs(usbg_gadget *g, int lang,
@@ -500,7 +500,7 @@ extern int usbg_get_gadget_strs(usbg_gadget *g, int lang,
  * @brief Set the USB gadget strings
  * @param g Pointer to gadget
  * @param lang USB language ID
- * @param g_sttrs Gadget attributes
+ * @param g_strs Gadget attributes
  * @return 0 on success usbg_error if error occurred
  */
 extern int usbg_set_gadget_strs(usbg_gadget *g, int lang,
@@ -599,7 +599,7 @@ extern int usbg_create_config(usbg_gadget *g, int id, const char *label,
 extern size_t usbg_get_config_label_len(usbg_config *c);
 
 /**
- * @brieg Get config label
+ * @brief Get config label
  * @param c Pointer to config
  * @param buf Buffer where label should be copied
  * @param len Length of given buffer
@@ -608,7 +608,7 @@ extern size_t usbg_get_config_label_len(usbg_config *c);
 extern int usbg_get_config_label(usbg_config *c, char *buf, size_t len);
 
 /**
- * @brieg Get config id
+ * @brief Get config id
  * @param c Pointer to config
  * @return Configuration id or usbg_error if error occurred.
  */
@@ -651,7 +651,7 @@ extern int usbg_set_config_bm_attrs(usbg_config *c, int bmAttributes);
  * @brief Get the USB configuration strings
  * @param c Pointer to configuration
  * @param lang Language of strings
- * @param c_sttrs Structure to be filled
+ * @param c_strs Structure to be filled
  * @return 0 on success or usbg_error if error occurred.
  */
 extern int usbg_get_config_strs(usbg_config *c, int lang,
@@ -661,7 +661,7 @@ extern int usbg_get_config_strs(usbg_config *c, int lang,
  * @brief Set the USB configuration strings
  * @param c Pointer to configuration
  * @param lang USB language ID
- * @param c_sttrs Configuration strings
+ * @param c_strs Configuration strings
  * @return 0 on success, usbg_error on failure.
  */
 extern int usbg_set_config_strs(usbg_config *c, int lang,
@@ -742,8 +742,8 @@ extern int usbg_disable_gadget(usbg_gadget *g);
 extern size_t usbg_get_gadget_udc_len(usbg_gadget *g);
 
 /**
- * @brieg Get name of udc to which gadget is binded
- * @param b Pointer to gadget
+ * @brief Get name of udc to which gadget is binded
+ * @param g Pointer to gadget
  * @param buf Buffer where udc name should be copied
  * @param len Length of given buffer
  * @return 0 on success or usbg_error if error occurred.
@@ -866,7 +866,7 @@ extern usbg_config *usbg_get_first_config(usbg_gadget *g);
 
 /**
  * @brief Get first binding in binding list
- * @param C Pointer to configuration
+ * @param c Pointer to configuration
  * @return Pointer to binding or NULL if list is empty.
  * @note Bindings are sorted in strings (name) order
  */
@@ -874,28 +874,28 @@ extern usbg_binding *usbg_get_first_binding(usbg_config *c);
 
 /**
  * @brief Get the next gadget on a list.
- * @pram g Pointer to current gadget
+ * @param g Pointer to current gadget
  * @return Next gadget or NULL if end of list.
  */
 extern usbg_gadget *usbg_get_next_gadget(usbg_gadget *g);
 
 /**
  * @brief Get the next function on a list.
- * @pram g Pointer to current function
+ * @param f Pointer to current function
  * @return Next function or NULL if end of list.
  */
 extern usbg_function *usbg_get_next_function(usbg_function *f);
 
 /**
  * @brief Get the next config on a list.
- * @pram g Pointer to current config
+ * @param c Pointer to current config
  * @return Next config or NULL if end of list.
  */
 extern usbg_config *usbg_get_next_config(usbg_config *c);
 
 /**
  * @brief Get the next binding on a list.
- * @pram g Pointer to current binding
+ * @param b Pointer to current binding
  * @return Next binding or NULL if end of list.
  */
 extern usbg_binding *usbg_get_next_binding(usbg_binding *b);
@@ -925,8 +925,6 @@ extern int usbg_export_config(usbg_config *c, FILE *stream);
  * @return 0 on success, usbg_error otherwise
  */
 extern int usbg_export_gadget(usbg_gadget *g, FILE *stream);
-
-/**
 
 /**
  * @brief Imports usb function from file and adds it to given gadget

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -93,7 +93,8 @@ typedef struct usbg_binding usbg_binding;
  * usbg_set_gadget_attr() function.
  */
 typedef enum {
-	BCD_USB = 0,
+	USBG_GADGET_ATTR_MIN = 0,
+	BCD_USB = USBG_GADGET_ATTR_MIN,
 	B_DEVICE_CLASS,
 	B_DEVICE_SUB_CLASS,
 	B_DEVICE_PROTOCOL,
@@ -101,6 +102,7 @@ typedef enum {
 	ID_VENDOR,
 	ID_PRODUCT,
 	BCD_DEVICE,
+	USBG_GADGET_ATTR_MAX,
 } usbg_gadget_attr;
 
 /**
@@ -155,7 +157,8 @@ typedef struct
  */
 typedef enum
 {
-	F_SERIAL,
+	USBG_FUNCTION_TYPE_MIN = 0,
+	F_SERIAL = USBG_FUNCTION_TYPE_MIN,
 	F_ACM,
 	F_OBEX,
 	F_ECM,
@@ -164,7 +167,8 @@ typedef enum
 	F_EEM,
 	F_RNDIS,
 	F_PHONET,
-	F_FFS
+	F_FFS,
+	USBG_FUNCTION_TYPE_MAX,
 } usbg_function_type;
 
 /**

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -319,7 +319,7 @@ static int usbg_lookup_function_type(const char *name)
 
 const const char *usbg_get_function_type_str(usbg_function_type type)
 {
-	return type > 0 && type < sizeof(function_names)/sizeof(char *) ?
+	return type >= 0 && type < sizeof(function_names)/sizeof(char *) ?
 			function_names[type] : NULL;
 }
 

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -316,18 +316,15 @@ static int usbg_lookup_function_type(const char *name)
 	int max = sizeof(function_names)/sizeof(char *);
 
 	if (!name)
-		return -1;
+		return USBG_ERROR_INVALID_PARAM;
 
 	do {
 		if (!strcmp(name, function_names[i]))
-			break;
+			return i;
 		i++;
 	} while (i != max);
 
-	if (i == max)
-		i = -1;
-
-	return i;
+	return USBG_ERROR_NOT_FOUND;
 }
 
 const const char *usbg_get_function_type_str(usbg_function_type type)

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -310,7 +310,7 @@ const char *usbg_strerror(usbg_error e)
 	return ret;
 }
 
-static int usbg_lookup_function_type(const char *name)
+int usbg_lookup_function_type(const char *name)
 {
 	int i = 0;
 	int max = sizeof(function_names)/sizeof(char *);

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2023,7 +2023,7 @@ int usbg_create_config(usbg_gadget *g, int id, const char *label,
 		usbg_config_attrs *c_attrs, usbg_config_strs *c_strs, usbg_config **c)
 {
 	char cpath[USBG_MAX_PATH_LENGTH];
-	usbg_config *conf;
+	usbg_config *conf = NULL;
 	int ret = USBG_ERROR_INVALID_PARAM;
 	int n, free_space;
 
@@ -2060,6 +2060,8 @@ int usbg_create_config(usbg_gadget *g, int id, const char *label,
 	n = snprintf(&(cpath[n]), free_space, "/%s", (*c)->name);
 	if (n < free_space) {
 		ret = USBG_ERROR_PATH_TOO_LONG;
+		usbg_free_config(conf);
+		goto out;
 	}
 
 	ret = mkdir(cpath, S_IRWXU | S_IRWXG | S_IRWXO);

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1323,13 +1323,13 @@ size_t usbg_get_configfs_path_len(usbg_state *s)
 
 int usbg_get_configfs_path(usbg_state *s, char *buf, size_t len)
 {
-	int ret = USBG_SUCCESS;
-	if (s && buf)
-		strncpy(buf, s->path, len);
-	else
-		ret = USBG_ERROR_INVALID_PARAM;
+	if (!s || !buf || len == 0)
+		return USBG_ERROR_INVALID_PARAM;
 
-	return ret;
+	buf[--len] = '\0';
+	strncpy(buf, s->path, len);
+
+	return USBG_SUCCESS;
 }
 
 usbg_gadget *usbg_get_gadget(usbg_state *s, const char *name)
@@ -1711,13 +1711,13 @@ size_t usbg_get_gadget_name_len(usbg_gadget *g)
 
 int usbg_get_gadget_name(usbg_gadget *g, char *buf, size_t len)
 {
-	int ret = USBG_SUCCESS;
-	if (g && buf)
-		strncpy(buf, g->name, len);
-	else
-		ret = USBG_ERROR_INVALID_PARAM;
+	if (!g || !buf || len == 0)
+		return USBG_ERROR_INVALID_PARAM;
 
-	return ret;
+	buf[--len] = '\0';
+	strncpy(buf, g->name, len);
+
+	return USBG_SUCCESS;
 }
 
 size_t usbg_get_gadget_udc_len(usbg_gadget *g)
@@ -1727,13 +1727,13 @@ size_t usbg_get_gadget_udc_len(usbg_gadget *g)
 
 int usbg_get_gadget_udc(usbg_gadget *g, char *buf, size_t len)
 {
-	int ret = USBG_SUCCESS;
-	if (g && buf)
-		strncpy(buf, g->udc, len);
-	else
-		ret = USBG_ERROR_INVALID_PARAM;
+	if (!g || !buf || len == 0)
+		return USBG_ERROR_INVALID_PARAM;
 
-	return ret;
+	buf[--len] = '\0';
+	strncpy(buf, g->udc, len);
+
+	return USBG_SUCCESS;
 }
 
 int usbg_set_gadget_attrs(usbg_gadget *g, usbg_gadget_attrs *g_attrs)
@@ -2094,13 +2094,13 @@ size_t usbg_get_config_label_len(usbg_config *c)
 
 int usbg_get_config_label(usbg_config *c, char *buf, size_t len)
 {
-	int ret = USBG_SUCCESS;
-	if (c && buf)
-		strncpy(buf, c->label, len);
-	else
-		ret = USBG_ERROR_INVALID_PARAM;
+	if (!c || !buf || len == 0)
+		return USBG_ERROR_INVALID_PARAM;
 
-	return ret;
+	buf[--len] = '\0';
+	strncpy(buf, c->label, len);
+
+	return USBG_SUCCESS;
 }
 
 int usbg_get_config_id(usbg_config *c)
@@ -2115,13 +2115,13 @@ size_t usbg_get_function_instance_len(usbg_function *f)
 
 int usbg_get_function_instance(usbg_function *f, char *buf, size_t len)
 {
-	int ret = USBG_SUCCESS;
-	if (f && buf)
-		strncpy(buf, f->instance, len);
-	else
-		ret = USBG_ERROR_INVALID_PARAM;
+	if (!f || !buf || len == 0)
+		return USBG_ERROR_INVALID_PARAM;
 
-	return ret;
+	buf[--len] = '\0';
+	strncpy(buf, f->instance, len);
+
+	return USBG_SUCCESS;
 }
 
 int usbg_set_config_attrs(usbg_config *c, usbg_config_attrs *c_attrs)
@@ -2274,13 +2274,13 @@ size_t usbg_get_binding_name_len(usbg_binding *b)
 
 int usbg_get_binding_name(usbg_binding *b, char *buf, size_t len)
 {
-	int ret = USBG_SUCCESS;
-	if (b && buf)
-		strncpy(buf, b->name, len);
-	else
-		ret = USBG_ERROR_INVALID_PARAM;
+	if (!b || !buf || len == 0)
+		return USBG_ERROR_INVALID_PARAM;
 
-	return ret;
+	buf[--len] = '\0';
+	strncpy(buf, b->name, len);
+
+	return USBG_SUCCESS;
 }
 
 int usbg_get_udcs(struct dirent ***udc_list)

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -3125,7 +3125,6 @@ static int usbg_export_gadget_prep(usbg_gadget *g, config_setting_t *root)
 	config_setting_t *node;
 	int ret = USBG_ERROR_NO_MEM;
 	int usbg_ret;
-	int cfg_ret;
 
 	/* We don't export name tag because name should be given during
 	 * loading of gadget */
@@ -3559,7 +3558,6 @@ out:
 static int usbg_import_config_bindings(config_setting_t *root, usbg_config *c)
 {
 	config_setting_t *node;
-	int usbg_ret, cfg_ret;
 	int ret = USBG_SUCCESS;
 	int count, i;
 
@@ -3588,7 +3586,6 @@ static int usbg_import_config_strs_lang(config_setting_t *root, usbg_config *c)
 	int lang;
 	const char *str;
 	usbg_config_strs c_strs = {0};
-	int usbg_ret, cfg_ret;
 	int ret = USBG_ERROR_INVALID_TYPE;
 
 	node = config_setting_get_member(root, USBG_LANG_TAG);
@@ -3624,7 +3621,6 @@ out:
 static int usbg_import_config_strings(config_setting_t *root, usbg_config *c)
 {
 	config_setting_t *node;
-	int usbg_ret, cfg_ret;
 	int ret = USBG_SUCCESS;
 	int count, i;
 
@@ -3648,9 +3644,8 @@ static int usbg_import_config_strings(config_setting_t *root, usbg_config *c)
 static int usbg_import_config_attrs(config_setting_t *root, usbg_config *c)
 {
 	config_setting_t *node;
-	int usbg_ret, cfg_ret;
+	int usbg_ret;
 	int bmAttributes, bMaxPower;
-	short format;
 	int ret = USBG_ERROR_INVALID_TYPE;
 
 	node = config_setting_get_member(root, "bmAttributes");
@@ -3773,7 +3768,6 @@ error2:
 static int usbg_import_gadget_configs(config_setting_t *root, usbg_gadget *g)
 {
 	config_setting_t *node, *id_node;
-	int usbg_ret, cfg_ret;
 	int id;
 	usbg_config *c;
 	int ret = USBG_SUCCESS;
@@ -3818,7 +3812,6 @@ static int usbg_import_gadget_configs(config_setting_t *root, usbg_gadget *g)
 static int usbg_import_gadget_functions(config_setting_t *root, usbg_gadget *g)
 {
 	config_setting_t *node, *inst_node;
-	int usbg_ret, cfg_ret;
 	const char *instance;
 	const char *label;
 	usbg_function *f;
@@ -3884,7 +3877,6 @@ static int usbg_import_gadget_strs_lang(config_setting_t *root, usbg_gadget *g)
 	int lang;
 	const char *str;
 	usbg_gadget_strs g_strs = {0};
-	int usbg_ret, cfg_ret;
 	int ret = USBG_ERROR_INVALID_TYPE;
 
 	node = config_setting_get_member(root, USBG_LANG_TAG);
@@ -3926,7 +3918,6 @@ out:
 static int usbg_import_gadget_strings(config_setting_t *root, usbg_gadget *g)
 {
 	config_setting_t *node;
-	int usbg_ret, cfg_ret;
 	int ret = USBG_SUCCESS;
 	int count, i;
 
@@ -3951,7 +3942,7 @@ static int usbg_import_gadget_strings(config_setting_t *root, usbg_gadget *g)
 static int usbg_import_gadget_attrs(config_setting_t *root, usbg_gadget *g)
 {
 	config_setting_t *node;
-	int usbg_ret, cfg_ret;
+	int usbg_ret;
 	int val;
 	int ret = USBG_ERROR_INVALID_TYPE;
 

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2058,7 +2058,7 @@ int usbg_create_config(usbg_gadget *g, int id, const char *label,
 	free_space = sizeof(cpath) - n;
 	/* Append string at the end of previous one */
 	n = snprintf(&(cpath[n]), free_space, "/%s", (*c)->name);
-	if (n < free_space) {
+	if (n >= free_space) {
 		ret = USBG_ERROR_PATH_TOO_LONG;
 		usbg_free_config(conf);
 		goto out;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1316,12 +1316,17 @@ void usbg_cleanup(usbg_state *s)
 	usbg_free_state(s);
 }
 
+const char *usbg_get_configfs_path(usbg_state *s)
+{
+	return s ? s->path : NULL;
+}
+
 size_t usbg_get_configfs_path_len(usbg_state *s)
 {
 	return s ? strlen(s->path) : USBG_ERROR_INVALID_PARAM;
 }
 
-int usbg_get_configfs_path(usbg_state *s, char *buf, size_t len)
+int usbg_cpy_configfs_path(usbg_state *s, char *buf, size_t len)
 {
 	if (!s || !buf || len == 0)
 		return USBG_ERROR_INVALID_PARAM;
@@ -1704,12 +1709,17 @@ int usbg_get_gadget_attrs(usbg_gadget *g, usbg_gadget_attrs *g_attrs)
 			: USBG_ERROR_INVALID_PARAM;
 }
 
+const char *usbg_get_gadget_name(usbg_gadget *g)
+{
+	return g ? g->name : NULL;
+}
+
 size_t usbg_get_gadget_name_len(usbg_gadget *g)
 {
 	return g ? strlen(g->name) : USBG_ERROR_INVALID_PARAM;
 }
 
-int usbg_get_gadget_name(usbg_gadget *g, char *buf, size_t len)
+int usbg_cpy_gadget_name(usbg_gadget *g, char *buf, size_t len)
 {
 	if (!g || !buf || len == 0)
 		return USBG_ERROR_INVALID_PARAM;
@@ -2087,12 +2097,17 @@ out:
 	return ret;
 }
 
+const char *usbg_get_config_label(usbg_config *c)
+{
+	return c ? c->label : NULL;
+}
+
 size_t usbg_get_config_label_len(usbg_config *c)
 {
 	return c ? strlen(c->label) : USBG_ERROR_INVALID_PARAM;
 }
 
-int usbg_get_config_label(usbg_config *c, char *buf, size_t len)
+int usbg_cpy_config_label(usbg_config *c, char *buf, size_t len)
 {
 	if (!c || !buf || len == 0)
 		return USBG_ERROR_INVALID_PARAM;
@@ -2108,12 +2123,17 @@ int usbg_get_config_id(usbg_config *c)
 	return c ? c->id : USBG_ERROR_INVALID_PARAM;
 }
 
+const char *usbg_get_function_instance(usbg_function *f)
+{
+	return f ? f->instance : NULL;
+}
+
 size_t usbg_get_function_instance_len(usbg_function *f)
 {
 	return f ? strlen(f->instance) : USBG_ERROR_INVALID_PARAM;
 }
 
-int usbg_get_function_instance(usbg_function *f, char *buf, size_t len)
+int usbg_cpy_function_instance(usbg_function *f, char *buf, size_t len)
 {
 	if (!f || !buf || len == 0)
 		return USBG_ERROR_INVALID_PARAM;
@@ -2267,12 +2287,17 @@ usbg_function *usbg_get_binding_target(usbg_binding *b)
 	return b ? b->target : NULL;
 }
 
+const char *usbg_get_binding_name(usbg_binding *b)
+{
+	return b ? b->name : NULL;
+}
+
 size_t usbg_get_binding_name_len(usbg_binding *b)
 {
 	return b ? strlen(b->name) : USBG_ERROR_INVALID_PARAM;
 }
 
-int usbg_get_binding_name(usbg_binding *b, char *buf, size_t len)
+int usbg_cpy_binding_name(usbg_binding *b, char *buf, size_t len)
 {
 	if (!b || !buf || len == 0)
 		return USBG_ERROR_INVALID_PARAM;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1291,7 +1291,7 @@ static int usbg_init_state(char *path, usbg_state *s)
 
 	ret = usbg_parse_gadgets(path, s);
 	if (ret != USBG_SUCCESS)
-		ERRORNO("unable to parse %s\n", path);
+		ERROR("unable to parse %s\n", path);
 
 	return ret;
 }
@@ -1330,7 +1330,7 @@ int usbg_init(const char *configfs_path, usbg_state **state)
 
 	ret = usbg_init_state(path, s);
 	if (ret != USBG_SUCCESS) {
-		ERRORNO("couldn't init gadget state\n");
+		ERROR("couldn't init gadget state\n");
 		usbg_free_state(s);
 		goto out;
 	}
@@ -2070,7 +2070,7 @@ int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 	*f = usbg_allocate_function(fpath, type, instance, g);
 	func = *f;
 	if (!func) {
-		ERRORNO("allocating function\n");
+		ERROR("allocating function\n");
 		ret = USBG_ERROR_NO_MEM;
 		goto out;
 	}
@@ -2130,7 +2130,7 @@ int usbg_create_config(usbg_gadget *g, int id, const char *label,
 	*c = usbg_allocate_config(cpath, label, id, g);
 	conf = *c;
 	if (!conf) {
-		ERRORNO("allocating configuration\n");
+		ERROR("allocating configuration\n");
 		ret = USBG_ERROR_NO_MEM;
 		goto out;
 	}

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -93,6 +93,19 @@ struct usbg_binding
 	char *path;
 };
 
+#define ARRAY_SIZE(array) (sizeof(array)/sizeof(*array))
+
+#define ARRAY_SIZE_SENTINEL(array, size)				\
+	static void __attribute__ ((unused)) array##_size_sentinel() 	\
+	{								\
+		char array##_smaller_than_expected[			\
+			(int)(ARRAY_SIZE(array) - size)]		\
+			__attribute__ ((unused));			\
+									\
+		char array##_larger_than_expected[			\
+			(int)(size - ARRAY_SIZE(array))]		\
+			__attribute__ ((unused));			\
+	}
 /**
  * @var function_names
  * @brief Name strings for supported USB function types
@@ -111,6 +124,8 @@ const char *function_names[] =
 	"ffs",
 };
 
+ARRAY_SIZE_SENTINEL(function_names, USBG_FUNCTION_TYPE_MAX);
+
 const char *gadget_attr_names[] =
 {
 	"bcdUSB",
@@ -122,6 +137,8 @@ const char *gadget_attr_names[] =
 	"idProduct",
 	"bcdDevice"
 };
+
+ARRAY_SIZE_SENTINEL(gadget_attr_names, USBG_GADGET_ATTR_MAX);
 
 #define ERROR(msg, ...) do {\
                         fprintf(stderr, "%s()  "msg" \n", \
@@ -312,8 +329,7 @@ const char *usbg_strerror(usbg_error e)
 
 int usbg_lookup_function_type(const char *name)
 {
-	int i = 0;
-	int max = sizeof(function_names)/sizeof(char *);
+	int i = USBG_FUNCTION_TYPE_MIN;
 
 	if (!name)
 		return USBG_ERROR_INVALID_PARAM;
@@ -322,21 +338,21 @@ int usbg_lookup_function_type(const char *name)
 		if (!strcmp(name, function_names[i]))
 			return i;
 		i++;
-	} while (i != max);
+	} while (i != USBG_FUNCTION_TYPE_MAX);
 
 	return USBG_ERROR_NOT_FOUND;
 }
 
 const const char *usbg_get_function_type_str(usbg_function_type type)
 {
-	return type >= 0 && type < sizeof(function_names)/sizeof(char *) ?
-			function_names[type] : NULL;
+	return type >= USBG_FUNCTION_TYPE_MIN &&
+		type < USBG_FUNCTION_TYPE_MAX ?
+		function_names[type] : NULL;
 }
 
 int usbg_lookup_gadget_attr(const char *name)
 {
-	int i = 0;
-	int max = sizeof(gadget_attr_names)/sizeof(char *);
+	int i = USBG_GADGET_ATTR_MIN;
 
 	if (!name)
 		return USBG_ERROR_INVALID_PARAM;
@@ -345,15 +361,16 @@ int usbg_lookup_gadget_attr(const char *name)
 		if (!strcmp(name, gadget_attr_names[i]))
 			return i;
 		i++;
-	} while (i != max);
+	} while (i != USBG_GADGET_ATTR_MAX);
 
 	return USBG_ERROR_NOT_FOUND;
 }
 
 const const char *usbg_get_gadget_attr_str(usbg_gadget_attr attr)
 {
-	return attr >= 0 && attr < sizeof(gadget_attr_names)/sizeof(char *) ?
-			gadget_attr_names[attr] : NULL;
+	return attr >= USBG_GADGET_ATTR_MIN &&
+		attr < USBG_GADGET_ATTR_MAX ?
+		gadget_attr_names[attr] : NULL;
 }
 
 static usbg_error usbg_split_function_instance_type(const char *full_name,


### PR DESCRIPTION
Dear Matt,

This series fixes a lot of bugs and makes API usage easier.

First two commits contains contains a difference between
libubsg/libusbg and kopasiak/libusbg repository.

List of fixed issues:
- doxygen typos
- Off-by-one error in usbg_get_function_type_str()
- remove unused variables
- Always append '\0' at the end of string

Also some small API changes has been done. Now user can choose
if he would like to get name as a constant string or copy the
name to his buffer. Of course name is valid only as long as 
related entity exist.

I have also added usbg_get/set_gadget_attr() to allow set
selected gadget attribute instead of using dedicated function
for each of them. It makes iteration over attributes much simpler.

Moreover, I would like to suggest you to not use github merge
button. This button makes allways non-fast-forrward merge
so it generates always a merge commit. We have only 6 pull requests
merged till now and the history looks a litlle bit weird.
When we get more and more commist the history will get unnecessarily
complicated. In additions a lot of merge commits in upstream branch
causes some problems in gbs (used to build rpms in tizen).
Of course this is not a must but only a suggestion.
