### PR TITLE
usbg: missing goto in usbg_create_config()

### DIFF
--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2060,6 +2060,7 @@ int usbg_create_config(usbg_gadget *g, int id, const char *label,
 	n = snprintf(&(cpath[n]), free_space, "/%s", (*c)->name);
 	if (n < free_space) {
 		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
 	}
 
 	ret = mkdir(cpath, S_IRWXU | S_IRWXG | S_IRWXO);


### PR DESCRIPTION
When there is not enough room for the whole path, the
error is set but the code continues anyway, overwriting
ther error. We probably want to break out of the function.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
