### PR TITLE
usbg.h: remove unclosed comment

### DIFF
--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -926,7 +926,6 @@ extern int usbg_export_config(usbg_config *c, FILE *stream);
  */
 extern int usbg_export_gadget(usbg_gadget *g, FILE *stream);
 
-/**
 
 /**
  * @brief Imports usb function from file and adds it to given gadget


### PR DESCRIPTION
This removes an unclosed comment block.  gcc complains mightly when including this if all warnings are enabled.

Looks like it was left over from some previous merge.

Signed-off-by: Greg Kroah-Hartman gregkh@linuxfoundation.org
